### PR TITLE
Add feedback mechanism

### DIFF
--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -9,6 +9,7 @@ class FeedbacksController < ApplicationController
     authorize @feedback
 
     if @feedback.save
+      FeedbackMailer.created(@feedback).deliver_now
       render json: serialize(@feedback), status: :created
     else
       render json: @feedback.errors, status: :unprocessable_entity

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -1,0 +1,38 @@
+class FeedbacksController < ApplicationController
+  before_action :authenticate_user!
+
+  skip_before_action :authorize_base_object!
+  before_action :set_and_authorize_user, only: [:create]
+
+  # POST /feedbacks
+  def create
+    @feedback = Feedback.new
+    @feedback.assign_attributes(permitted_attributes(@feedback))
+    authorize @feedback
+
+    if @feedback.save
+      render json: serialize(@feedback), status: :created, location: @feedback
+    else
+      render json: @feedback.errors, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def base_object
+    Feedback
+  end
+
+  def permitted_attributes(...)
+    super.merge(user_id: current_user.id)
+  end
+
+  def serialize(target, serializer: FeedbackSerializer)
+    super
+  end
+
+  def set_and_authorize_user
+    @user = policy_scope(base_object).find(params[:id])
+    authorize @user
+  end
+end

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -1,8 +1,6 @@
 class FeedbacksController < ApplicationController
   before_action :authenticate_user!
-
   skip_before_action :authorize_base_object!
-  before_action :set_and_authorize_user, only: [:create]
 
   # POST /feedbacks
   def create
@@ -11,7 +9,7 @@ class FeedbacksController < ApplicationController
     authorize @feedback
 
     if @feedback.save
-      render json: serialize(@feedback), status: :created, location: @feedback
+      render json: serialize(@feedback), status: :created
     else
       render json: @feedback.errors, status: :unprocessable_entity
     end

--- a/app/mailers/feedback_mailer.rb
+++ b/app/mailers/feedback_mailer.rb
@@ -1,0 +1,14 @@
+class FeedbackMailer < ApplicationMailer
+  # Subject can be set in your I18n file at config/locales/en.yml
+  # with the following lookup:
+  #
+  #   en.feedback_mailer.created.subject
+  #
+  def created(feedback)
+    return unless ENV["FEEDBACK_EMAIL_ADDRESS"]
+
+    @feedback = feedback
+
+    mail to: ENV.fetch("FEEDBACK_EMAIL_ADDRESS"), subject: I18n.t("feedback_mailer.created.subject")
+  end
+end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -1,5 +1,5 @@
 class Feedback < ApplicationRecord
-  belongs_to :user
+  belongs_to :user, required: true
 
   validates :subject, presence: true
   validates :content, presence: true

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -1,0 +1,6 @@
+class Feedback < ApplicationRecord
+  belongs_to :user
+
+  validates :subject, presence: true
+  validates :content, presence: true
+end

--- a/app/policies/feedback_policy.rb
+++ b/app/policies/feedback_policy.rb
@@ -8,7 +8,7 @@ class FeedbackPolicy < ApplicationPolicy
   end
 
   def create?
-    @user.roles.any?
+    !@user.is_archived
   end
 
   def edit?
@@ -24,7 +24,7 @@ class FeedbackPolicy < ApplicationPolicy
   end
 
   def permitted_attributes
-    [:subject, :content, :user_id]
+    [:subject, :content]
   end
 
   class Scope < Scope

--- a/app/policies/feedback_policy.rb
+++ b/app/policies/feedback_policy.rb
@@ -1,0 +1,35 @@
+class FeedbackPolicy < ApplicationPolicy
+  def index?
+    false
+  end
+
+  def show?
+    false
+  end
+
+  def create?
+    @user.roles.any?
+  end
+
+  def edit?
+    false
+  end
+
+  def update?
+    false
+  end
+
+  def destroy?
+    false
+  end
+
+  def permitted_attributes
+    [:subject, :content, :user_id]
+  end
+
+  class Scope < Scope
+    def resolve
+      scope.all
+    end
+  end
+end

--- a/app/serializers/feedback_serializer.rb
+++ b/app/serializers/feedback_serializer.rb
@@ -1,0 +1,7 @@
+class FeedbackSerializer
+  include FastVersionedSerializer
+
+  attributes :user_id, :subject, :content
+
+  set_type :feedbacks
+end

--- a/app/serializers/feedback_serializer.rb
+++ b/app/serializers/feedback_serializer.rb
@@ -1,5 +1,5 @@
 class FeedbackSerializer
-  include FastVersionedSerializer
+  include FastApplicationSerializer
 
   attributes :user_id, :subject, :content
 

--- a/app/views/feedback_mailer/created.en.html.erb
+++ b/app/views/feedback_mailer/created.en.html.erb
@@ -1,0 +1,9 @@
+<h1>New Feedback</h1>
+
+<p>
+  Subject: <%= @feedback.subject %>
+</p>
+
+<p>
+  <%= @feedback.content %>
+</p>

--- a/app/views/feedback_mailer/created.en.text.erb
+++ b/app/views/feedback_mailer/created.en.text.erb
@@ -1,0 +1,6 @@
+New Feedback
+
+Subject: <%= @feedback.subject %>
+
+Content:
+<%= @feedback.content %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
   resources :actors
   resources :actortype_taxonomies, only: [:index, :show]
   resources :actortypes, only: [:index, :show]
+  resources :feedbacks, only: [:create]
   resources :measure_actors, only: [:index, :show, :create, :update, :destroy]
   resources :measure_categories
   resources :measure_indicators

--- a/db/migrate/20240515082006_create_feedbacks.rb
+++ b/db/migrate/20240515082006_create_feedbacks.rb
@@ -1,0 +1,12 @@
+class CreateFeedbacks < ActiveRecord::Migration[6.1]
+  def change
+    create_table :feedbacks do |t|
+      t.text :subject
+      t.text :content
+      t.belongs_to :user, null: false, foreign_key: true, index: true
+      t.datetime :notified_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240515082006_create_feedbacks.rb
+++ b/db/migrate/20240515082006_create_feedbacks.rb
@@ -4,7 +4,7 @@ class CreateFeedbacks < ActiveRecord::Migration[6.1]
       t.text :subject
       t.text :content
       t.belongs_to :user, null: false, foreign_key: true, index: true
-      t.datetime :notified_at
+      t.datetime :sent_at
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -136,7 +136,7 @@ ActiveRecord::Schema.define(version: 2024_05_15_082006) do
     t.text "subject"
     t.text "content"
     t.bigint "user_id", null: false
-    t.datetime "notified_at"
+    t.datetime "sent_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_feedbacks_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_04_29_205738) do
+ActiveRecord::Schema.define(version: 2024_05_15_082006) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -130,6 +130,16 @@ ActiveRecord::Schema.define(version: 2024_04_29_205738) do
     t.integer "created_by_id"
     t.index ["draft"], name: "index_due_dates_on_draft"
     t.index ["indicator_id"], name: "index_due_dates_on_indicator_id"
+  end
+
+  create_table "feedbacks", force: :cascade do |t|
+    t.text "subject"
+    t.text "content"
+    t.bigint "user_id", null: false
+    t.datetime "notified_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_feedbacks_on_user_id"
   end
 
   create_table "framework_frameworks", id: :serial, force: :cascade do |t|
@@ -498,6 +508,7 @@ ActiveRecord::Schema.define(version: 2024_04_29_205738) do
   add_foreign_key "actors", "actortypes"
   add_foreign_key "actortype_taxonomies", "actortypes"
   add_foreign_key "actortype_taxonomies", "taxonomies"
+  add_foreign_key "feedbacks", "users"
   add_foreign_key "framework_frameworks", "frameworks"
   add_foreign_key "framework_frameworks", "frameworks", column: "other_framework_id"
   add_foreign_key "framework_taxonomies", "frameworks"

--- a/spec/controllers/feedbacks_controller_spec.rb
+++ b/spec/controllers/feedbacks_controller_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+require "json"
+
+RSpec.describe FeedbacksController, type: :controller do
+  describe "POST create" do
+    context "when not signed in" do
+      it "not allow creating a feedback" do
+        post :create, format: :json, params: {feedback: {subject: "Test", content: "Test"}}
+        expect(response).to be_unauthorized
+      end
+    end
+
+
+  end
+end

--- a/spec/controllers/feedbacks_controller_spec.rb
+++ b/spec/controllers/feedbacks_controller_spec.rb
@@ -13,6 +13,12 @@ RSpec.describe FeedbacksController, type: :controller do
       it "not allow creating a feedback" do
         expect(subject).to be_unauthorized
       end
+
+      it "will not send a notification" do
+        expect(FeedbackMailer).not_to receive(:created)
+
+        subject
+      end
     end
 
     context "when signed in" do
@@ -26,6 +32,12 @@ RSpec.describe FeedbacksController, type: :controller do
           json = JSON.parse(subject.body)
           expect(json["data"]["attributes"]["user_id"]).to eq(user.id)
         end
+
+        it "will send a notification" do
+          expect(FeedbackMailer).to receive(:created).and_call_original
+
+          subject
+        end
       end
 
       context "as an analyst" do
@@ -35,6 +47,12 @@ RSpec.describe FeedbacksController, type: :controller do
           expect(subject).to be_created
           json = JSON.parse(subject.body)
           expect(json["data"]["attributes"]["user_id"]).to eq(user.id)
+        end
+
+        it "will send a notification" do
+          expect(FeedbackMailer).to receive(:created).and_call_original
+
+          subject
         end
       end
 
@@ -46,6 +64,12 @@ RSpec.describe FeedbacksController, type: :controller do
           json = JSON.parse(subject.body)
           expect(json["data"]["attributes"]["user_id"]).to eq(user.id)
         end
+
+        it "will send a notification" do
+          expect(FeedbackMailer).to receive(:created).and_call_original
+
+          subject
+        end
       end
 
       context "as a manager" do
@@ -55,6 +79,12 @@ RSpec.describe FeedbacksController, type: :controller do
           expect(subject).to be_created
           json = JSON.parse(subject.body)
           expect(json["data"]["attributes"]["user_id"]).to eq(user.id)
+        end
+
+        it "will send a notification" do
+          expect(FeedbackMailer).to receive(:created).and_call_original
+
+          subject
         end
       end
     end

--- a/spec/controllers/feedbacks_controller_spec.rb
+++ b/spec/controllers/feedbacks_controller_spec.rb
@@ -3,13 +3,60 @@ require "json"
 
 RSpec.describe FeedbacksController, type: :controller do
   describe "POST create" do
+    subject do
+      post :create,
+        format: :json,
+        params: {feedback: {subject: "Test Subject", content: "Test Content"}}
+    end
+
     context "when not signed in" do
       it "not allow creating a feedback" do
-        post :create, format: :json, params: {feedback: {subject: "Test", content: "Test"}}
-        expect(response).to be_unauthorized
+        expect(subject).to be_unauthorized
       end
     end
 
+    context "when signed in" do
+      before { sign_in user }
 
+      context "as a guest" do
+        let(:user) { FactoryBot.create(:user) }
+
+        it "will create a feedback" do
+          expect(subject).to be_created
+          json = JSON.parse(subject.body)
+          expect(json["data"]["attributes"]["user_id"]).to eq(user.id)
+        end
+      end
+
+      context "as an analyst" do
+        let(:user) { FactoryBot.create(:user, :analyst) }
+
+        it "will create a feedback" do
+          expect(subject).to be_created
+          json = JSON.parse(subject.body)
+          expect(json["data"]["attributes"]["user_id"]).to eq(user.id)
+        end
+      end
+
+      context "as an admin" do
+        let(:user) { FactoryBot.create(:user, :admin) }
+
+        it "will create a feedback" do
+          expect(subject).to be_created
+          json = JSON.parse(subject.body)
+          expect(json["data"]["attributes"]["user_id"]).to eq(user.id)
+        end
+      end
+
+      context "as a manager" do
+        let(:user) { FactoryBot.create(:user, :manager) }
+
+        it "will create a feedback" do
+          expect(subject).to be_created
+          json = JSON.parse(subject.body)
+          expect(json["data"]["attributes"]["user_id"]).to eq(user.id)
+        end
+      end
+    end
   end
 end

--- a/spec/factories/feedbacks.rb
+++ b/spec/factories/feedbacks.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :feedback do
+    association(:user)
+    comment { Faker::Lorem.paragraph }
+    rating { rand(1..5) }
+  end
+end

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe Feedback, type: :model do
+  it { is_expected.to belong_to :user }
+  it { is_expected.to validate_presence_of :subject }
+  it { is_expected.to validate_presence_of :content }
+end


### PR DESCRIPTION
We want to allow signed in user to leave feedback and have this
persisted in the database as `feedbacks` and available through the API
at `/feedbacks`.

When new feedback is received, the system will send an email to the
configured email address, set by `ENV["FEEDBACK_EMAIL_ADDRESS"]`.

Resolves #104 