### PR TITLE
Fix: `bin/kamal` took over `bin/bundle`

### DIFF
--- a/bin/bundle
+++ b/bin/bundle
@@ -41,7 +41,7 @@ m = Module.new do
     gemfile = ENV["BUNDLE_GEMFILE"]
     return gemfile if gemfile && !gemfile.empty?
 
-    File.expand_path("../gemfiles/deploy", __dir__)
+    File.expand_path("../Gemfile", __dir__)
   end
 
   def lockfile


### PR DESCRIPTION
This prevents most commands from working e.g. `bin/rake`, and `bin/kamal`
sets `BUNDLE_GEMFILE` manually so should still work.